### PR TITLE
Add zone direction filtering

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -730,6 +730,9 @@ cameras:
         inertia: 3
         # Optional: Number of seconds that an object must loiter to be considered in the zone (default: shown below)
         loitering_time: 0
+        # Optional: Only count objects moving in this angle range
+        # Angles are measured counter-clockwise from the right side of the frame
+        angle_range: 140,220
         # Optional: List of objects that can trigger this zone (default: all tracked objects)
         objects:
           - person

--- a/docs/docs/configuration/zones.md
+++ b/docs/docs/configuration/zones.md
@@ -187,3 +187,20 @@ cameras:
         inertia: 1
         speed_threshold: 20 # unit is in kph or mph, depending on how unit_system is set (see above)
 ```
+
+### Direction Filter
+
+You can filter objects in a zone based on the direction they are moving. Provide
+an `angle_range` with a start and end angle in degrees. Angles are measured
+counter-clockwise from the right side of the frame.
+
+```yaml
+cameras:
+  name_of_your_camera:
+    zones:
+      driveway:
+        coordinates: ...
+        angle_range: 140,220
+```
+Only objects with a movement angle between 140° and 220° will be considered
+inside the `driveway` zone.

--- a/frigate/config/camera/zone.py
+++ b/frigate/config/camera/zone.py
@@ -38,6 +38,10 @@ class ZoneConfig(BaseModel):
         ge=0.1,
         title="Minimum speed value for an object to be considered in the zone.",
     )
+    angle_range: Optional[Union[str, list[str]]] = Field(
+        default=None,
+        title="Allowed movement angle range (start,end) in degrees.",
+    )
     objects: Union[str, list[str]] = Field(
         default_factory=list,
         title="List of objects that can trigger the zone.",
@@ -78,6 +82,28 @@ class ZoneConfig(BaseModel):
             raise ValueError("distances must have exactly 4 values")
 
         return distances
+
+    @field_validator("angle_range", mode="before")
+    @classmethod
+    def validate_angle_range(cls, v):
+        if v is None:
+            return None
+
+        if isinstance(v, str):
+            angles = [float(val) for val in v.split(",")]
+        elif isinstance(v, list):
+            angles = [float(val) for val in v]
+        else:
+            raise ValueError("Invalid type for angle_range")
+
+        if len(angles) != 2:
+            raise ValueError("angle_range must have exactly 2 values")
+
+        min_a, max_a = angles
+        if not (0 <= min_a <= 360 and 0 <= max_a <= 360):
+            raise ValueError("angle_range values must be between 0 and 360")
+
+        return [str(min_a), str(max_a)]
 
     @model_validator(mode="after")
     def check_loitering_time_constraints(self):

--- a/frigate/track/tracked_object.py
+++ b/frigate/track/tracked_object.py
@@ -27,7 +27,7 @@ from frigate.util.image import (
     is_better_thumbnail,
 )
 from frigate.util.object import box_inside
-from frigate.util.velocity import calculate_real_world_speed
+from frigate.util.velocity import calculate_pixel_angle, calculate_real_world_speed
 
 logger = logging.getLogger(__name__)
 
@@ -185,6 +185,16 @@ class TrackedObject:
 
             # check if the object is in the zone
             if cv2.pointPolygonTest(contour, bottom_center, False) >= 0:
+                if zone.angle_range:
+                    angle = calculate_pixel_angle(obj_data["estimate_velocity"])
+                    self.velocity_angle = sanitize_float(angle)
+                    start, end = [float(a) for a in zone.angle_range]
+                    if start <= end:
+                        if not (start <= angle <= end):
+                            continue
+                    else:
+                        if not (angle >= start or angle <= end):
+                            continue
                 # if the object passed the filters once, dont apply again
                 if name in self.current_zones or not zone_filtered(self, zone.filters):
                     # Calculate speed first if this is a speed zone

--- a/frigate/util/velocity.py
+++ b/frigate/util/velocity.py
@@ -125,3 +125,17 @@ def calculate_real_world_speed(
         angle += 360
 
     return speed_magnitude, angle
+
+
+def calculate_pixel_angle(velocity_pixels) -> float:
+    """Return the angle of a velocity vector in pixel units."""
+    if not isinstance(velocity_pixels, np.ndarray):
+        velocity_pixels = np.array(velocity_pixels)
+
+    avg_velocity_pixels = velocity_pixels.mean(axis=0)
+    dx, dy = avg_velocity_pixels
+    angle = math.degrees(math.atan2(dy, dx))
+    if angle < 0:
+        angle += 360
+
+    return angle


### PR DESCRIPTION
## Summary
- allow angle-based filters on zones via `angle_range`
- compute object direction from tracked velocity
- filter tracked objects by direction when evaluating zones
- document new setting in zones docs and reference

## Testing
- `ruff format frigate docs`
- `ruff check frigate docs docker *.py`
- `python3 -m mypy --config-file frigate/mypy.ini frigate` *(fails: Library stubs not installed)*
- `python3 -m unittest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_68430332333483329e35d197e1366879