### PR TITLE
Expose zone direction filtering via API and UI

### DIFF
--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -14,3 +14,7 @@ cameras:
       height: 1080
       width: 1920
       fps: 5
+    zones:
+      driveway:
+        coordinates: 0,0,1,0,1,1,0,1
+        angle_range: 140,220

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -730,6 +730,9 @@ cameras:
         inertia: 3
         # Optional: Number of seconds that an object must loiter to be considered in the zone (default: shown below)
         loitering_time: 0
+        # Optional: Only count objects moving in this angle range
+        # Angles are measured counter-clockwise from the right side of the frame
+        angle_range: 140,220
         # Optional: List of objects that can trigger this zone (default: all tracked objects)
         objects:
           - person

--- a/docs/docs/configuration/zones.md
+++ b/docs/docs/configuration/zones.md
@@ -187,3 +187,20 @@ cameras:
         inertia: 1
         speed_threshold: 20 # unit is in kph or mph, depending on how unit_system is set (see above)
 ```
+
+### Direction Filter
+
+You can filter objects in a zone based on the direction they are moving. Provide
+an `angle_range` with a start and end angle in degrees. Angles are measured
+counter-clockwise from the right side of the frame.
+
+```yaml
+cameras:
+  name_of_your_camera:
+    zones:
+      driveway:
+        coordinates: ...
+        angle_range: 140,220
+```
+Only objects with a movement angle between 140° and 220° will be considered
+inside the `driveway` zone.

--- a/docs/docs/development/contributing.md
+++ b/docs/docs/development/contributing.md
@@ -80,6 +80,7 @@ Create and place these files in a `debug` folder in the root of the repo. This i
 VS Code will start the Docker Compose file for you and open a terminal window connected to `frigate-dev`.
 
 - Depending on what hardware you're developing on, you may need to amend `docker-compose.yml` in the project root to pass through a USB Coral or GPU for hardware acceleration.
+- Run `make version` before `python3 -m frigate` if running outside the dev container to generate `frigate/version.py`.
 - Run `python3 -m frigate` to start the backend.
 - In a separate terminal window inside VS Code, change into the `web` directory and run `npm install && npm run dev` to start the frontend.
 
@@ -153,6 +154,9 @@ cd web && npm install
 ```console
 cd web && npm run dev
 ```
+The dev server listens on port `5173`, which is forwarded automatically by the
+dev container (see `.devcontainer/devcontainer.json`). Open
+`http://localhost:5173` in your browser to view the UI.
 
 ##### 3a. Run the development server against a non-local instance
 

--- a/frigate/api/defs/tags.py
+++ b/frigate/api/defs/tags.py
@@ -12,3 +12,4 @@ class Tags(Enum):
     events = "Events"
     classification = "classification"
     auth = "Auth"
+    zones = "Zones"

--- a/frigate/api/fastapi_app.py
+++ b/frigate/api/fastapi_app.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import asynccontextmanager
 from typing import Optional
 
 from fastapi import FastAPI, Request
@@ -7,7 +8,8 @@ from playhouse.sqliteq import SqliteQueueDatabase
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
-from starlette_context import middleware, plugins
+from starlette_context import plugins
+from starlette_context.middleware import RawContextMiddleware
 from starlette_context.plugins import Plugin
 
 from frigate.api import app as main_app
@@ -20,6 +22,7 @@ from frigate.api import (
     notification,
     preview,
     review,
+    zone,
 )
 from frigate.api.auth import get_jwt_secret, limiter
 from frigate.comms.event_metadata_updater import (
@@ -32,6 +35,12 @@ from frigate.stats.emitter import StatsEmitter
 from frigate.storage import StorageMaintainer
 
 logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logger.info("FastAPI started")
+    yield
 
 
 def check_csrf(request: Request) -> bool:
@@ -62,12 +71,13 @@ def create_fastapi_app(
     app = FastAPI(
         debug=False,
         swagger_ui_parameters={"apisSorter": "alpha", "operationsSorter": "alpha"},
+        lifespan=lifespan,
     )
 
     # update the request_address with the x-forwarded-for header from nginx
     # https://starlette-context.readthedocs.io/en/latest/plugins.html#forwarded-for
     app.add_middleware(
-        middleware.ContextMiddleware,
+        RawContextMiddleware,
         plugins=(plugins.ForwardedForPlugin(),),
     )
 
@@ -93,10 +103,6 @@ def create_fastapi_app(
             database.close()
         return response
 
-    @app.on_event("startup")
-    async def startup():
-        logger.info("FastAPI started")
-
     # Rate limiter (used for login endpoint)
     if frigate_config.auth.failed_login_rate_limit is None:
         limiter.enabled = False
@@ -112,6 +118,7 @@ def create_fastapi_app(
     app.include_router(auth.router)
     app.include_router(classification.router)
     app.include_router(review.router)
+    app.include_router(zone.router)
     app.include_router(main_app.router)
     app.include_router(preview.router)
     app.include_router(notification.router)

--- a/frigate/api/zone.py
+++ b/frigate/api/zone.py
@@ -1,0 +1,62 @@
+from fastapi import APIRouter, Body, Depends, Request
+from fastapi.responses import JSONResponse
+
+from frigate.api.auth import require_role
+from frigate.api.defs.tags import Tags
+from frigate.config import FrigateConfig
+from frigate.util.builtin import update_yaml_from_url
+from frigate.util.config import find_config_file
+
+router = APIRouter(tags=[Tags.zones])
+
+
+@router.get("/zones/{camera}/{zone}/direction")
+def get_zone_direction(request: Request, camera: str, zone: str):
+    config: FrigateConfig = request.app.frigate_config
+    camera_cfg = config.cameras.get(camera)
+    if not camera_cfg or zone not in camera_cfg.zones:
+        return JSONResponse(status_code=404, content="Zone not found")
+
+    return {"angle_range": camera_cfg.zones[zone].angle_range}
+
+
+@router.put(
+    "/zones/{camera}/{zone}/direction",
+    dependencies=[Depends(require_role(["admin"]))],
+)
+def set_zone_direction(
+    request: Request,
+    camera: str,
+    zone: str,
+    body: dict = Body(...),
+):
+    angle_range = body.get("angle_range")
+    if (
+        angle_range is None
+        or not isinstance(angle_range, list)
+        or len(angle_range) != 2
+    ):
+        return JSONResponse(
+            status_code=400,
+            content={"success": False, "message": "angle_range list required"},
+        )
+
+    angle_str = f"{angle_range[0]},{angle_range[1]}"
+
+    config_file = find_config_file()
+    try:
+        update_yaml_from_url(
+            config_file,
+            f"?cameras.{camera}.zones.{zone}.angle_range={angle_str}",
+        )
+        with open(config_file, "r") as f:
+            new_raw_config = f.read()
+
+        config = FrigateConfig.parse_yaml(new_raw_config)
+        request.app.frigate_config = config
+    except Exception as e:
+        return JSONResponse(
+            content={"success": False, "message": str(e)}, status_code=400
+        )
+
+    return JSONResponse(content={"success": True, "angle_range": angle_range})

--- a/frigate/config/camera/zone.py
+++ b/frigate/config/camera/zone.py
@@ -38,6 +38,10 @@ class ZoneConfig(BaseModel):
         ge=0.1,
         title="Minimum speed value for an object to be considered in the zone.",
     )
+    angle_range: Optional[Union[str, list[str]]] = Field(
+        default=None,
+        title="Allowed movement angle range (start,end) in degrees.",
+    )
     objects: Union[str, list[str]] = Field(
         default_factory=list,
         title="List of objects that can trigger the zone.",
@@ -78,6 +82,28 @@ class ZoneConfig(BaseModel):
             raise ValueError("distances must have exactly 4 values")
 
         return distances
+
+    @field_validator("angle_range", mode="before")
+    @classmethod
+    def validate_angle_range(cls, v):
+        if v is None:
+            return None
+
+        if isinstance(v, str):
+            angles = [float(val) for val in v.split(",")]
+        elif isinstance(v, list):
+            angles = [float(val) for val in v]
+        else:
+            raise ValueError("Invalid type for angle_range")
+
+        if len(angles) != 2:
+            raise ValueError("angle_range must have exactly 2 values")
+
+        min_a, max_a = angles
+        if not (0 <= min_a <= 360 and 0 <= max_a <= 360):
+            raise ValueError("angle_range values must be between 0 and 360")
+
+        return [str(min_a), str(max_a)]
 
     @model_validator(mode="after")
     def check_loitering_time_constraints(self):

--- a/frigate/test/test_http.py
+++ b/frigate/test/test_http.py
@@ -44,6 +44,12 @@ class TestHttp(unittest.TestCase):
                         "width": 1920,
                         "fps": 5,
                     },
+                    "zones": {
+                        "driveway": {
+                            "coordinates": "0,0,1,0,1,1,0,1",
+                            "angle_range": "140,220",
+                        }
+                    },
                 }
             },
         }
@@ -354,6 +360,32 @@ class TestHttp(unittest.TestCase):
             recording = response.json()
             assert recording
             assert recording[0]["id"] == id
+
+    def test_zone_direction(self):
+        app = create_fastapi_app(
+            FrigateConfig(**self.minimal_config),
+            self.db,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+        with TestClient(app) as client:
+            resp = client.get("/zones/front_door/driveway/direction")
+            assert resp.status_code == 200
+            assert resp.json() == {"angle_range": ["140", "220"]}
+
+            resp = client.put(
+                "/zones/front_door/driveway/direction",
+                json={"angle_range": ["100", "200"]},
+                headers={"remote-role": "admin"},
+            )
+            assert resp.status_code == 200
+            resp = client.get("/zones/front_door/driveway/direction")
+            assert resp.json()["angle_range"] == ["100", "200"]
 
 
 def _insert_mock_event(

--- a/frigate/track/tracked_object.py
+++ b/frigate/track/tracked_object.py
@@ -27,7 +27,7 @@ from frigate.util.image import (
     is_better_thumbnail,
 )
 from frigate.util.object import box_inside
-from frigate.util.velocity import calculate_real_world_speed
+from frigate.util.velocity import calculate_pixel_angle, calculate_real_world_speed
 
 logger = logging.getLogger(__name__)
 
@@ -185,6 +185,16 @@ class TrackedObject:
 
             # check if the object is in the zone
             if cv2.pointPolygonTest(contour, bottom_center, False) >= 0:
+                if zone.angle_range:
+                    angle = calculate_pixel_angle(obj_data["estimate_velocity"])
+                    self.velocity_angle = sanitize_float(angle)
+                    start, end = [float(a) for a in zone.angle_range]
+                    if start <= end:
+                        if not (start <= angle <= end):
+                            continue
+                    else:
+                        if not (angle >= start or angle <= end):
+                            continue
                 # if the object passed the filters once, dont apply again
                 if name in self.current_zones or not zone_filtered(self, zone.filters):
                     # Calculate speed first if this is a speed zone

--- a/frigate/util/velocity.py
+++ b/frigate/util/velocity.py
@@ -125,3 +125,17 @@ def calculate_real_world_speed(
         angle += 360
 
     return speed_magnitude, angle
+
+
+def calculate_pixel_angle(velocity_pixels) -> float:
+    """Return the angle of a velocity vector in pixel units."""
+    if not isinstance(velocity_pixels, np.ndarray):
+        velocity_pixels = np.array(velocity_pixels)
+
+    avg_velocity_pixels = velocity_pixels.mean(axis=0)
+    dx, dy = avg_velocity_pixels
+    angle = math.degrees(math.atan2(dy, dx))
+    if angle < 0:
+        angle += 360
+
+    return angle

--- a/migrations/016_sublabel_increase.py
+++ b/migrations/016_sublabel_increase.py
@@ -4,8 +4,8 @@ from frigate.models import Event
 
 
 def migrate(migrator, database, fake=False, **kwargs):
-    migrator.change_columns(Event, sub_label=pw.CharField(max_length=100, null=True))
+    migrator.change_fields(Event, sub_label=pw.CharField(max_length=100, null=True))
 
 
 def rollback(migrator, database, fake=False, **kwargs):
-    migrator.change_columns(Event, sub_label=pw.CharField(max_length=20, null=True))
+    migrator.change_fields(Event, sub_label=pw.CharField(max_length=20, null=True))

--- a/migrations/030_create_user_review_status.py
+++ b/migrations/030_create_user_review_status.py
@@ -74,7 +74,7 @@ def migrate(migrator, database, fake=False, **kwargs):
                 )
 
     if not fake:  # Only run data migration if not faking
-        migrator.python(migrate_data)
+        migrator.run(migrate_data)
 
     migrator.sql('ALTER TABLE "reviewsegment" DROP COLUMN "has_been_reviewed"')
 

--- a/web/public/locales/en/views/settings.json
+++ b/web/public/locales/en/views/settings.json
@@ -219,6 +219,11 @@
           "mustBeGreaterOrEqualZero": "Loitering time must be greater than or equal to 0."
         }
       },
+      "angle": {
+        "error": {
+          "range": "Angle must be between 0 and 360."
+        }
+      },
       "speed": {
         "error": {
           "mustBeGreaterOrEqualTo": "Speed threshold must greater than or equal to 0.1."
@@ -291,6 +296,12 @@
             "loiteringTimeError": "Zones with loitering times greater than 0 should not be used with speed estimation."
           }
         }
+      },
+      "directionFilter": {
+        "title": "Direction Filter",
+        "desc": "Only count objects moving within this angle range (degrees).",
+        "start": "Start angle",
+        "end": "End angle"
       },
       "toast": {
         "success": "Zone ({{zoneName}}) has been saved. Restart Frigate to apply changes."

--- a/web/public/locales/fr/views/settings.json
+++ b/web/public/locales/fr/views/settings.json
@@ -320,6 +320,11 @@
           "mustBeGreaterOrEqualZero": "Le temps de latence doit être supérieur ou égal à 0."
         }
       },
+      "angle": {
+        "error": {
+          "range": "L'angle doit être compris entre 0 et 360."
+        }
+      },
       "inertia": {
         "error": {
           "mustBeAboveZero": "L'inertie doit être supérieure à 0."
@@ -366,6 +371,12 @@
             "pointLengthError": "L'estimation de vitesse a été désactivée pour cette zone. Les zones avec estimation de vitesse doivent comporter exactement 4 points."
           }
         }
+      },
+      "directionFilter": {
+        "title": "Filtre de direction",
+        "desc": "Ne compter que les objets se déplaçant dans cette plage d'angles (degrés).",
+        "start": "Angle de début",
+        "end": "Angle de fin"
       },
       "point_one": "{{count}} point",
       "point_many": "{{count}} points",

--- a/web/src/components/settings/ZoneEditPane.tsx
+++ b/web/src/components/settings/ZoneEditPane.tsx
@@ -103,6 +103,17 @@ export default function ZoneEditPane({
       : [undefined, undefined, undefined, undefined];
   }, [polygon, config]);
 
+  const [angleStart, angleEnd] = useMemo(() => {
+    const range =
+      polygon?.camera &&
+      polygon?.name &&
+      config?.cameras[polygon.camera]?.zones[polygon.name]?.angle_range;
+
+    return Array.isArray(range)
+      ? [parseFloat(range[0]) || 0, parseFloat(range[1]) || 0]
+      : [undefined, undefined];
+  }, [polygon, config]);
+
   const formSchema = z
     .object({
       name: z
@@ -206,6 +217,18 @@ export default function ZoneEditPane({
         })
         .optional()
         .or(z.literal("")),
+      angle_start: z.coerce
+        .number()
+        .min(0, { message: t("masksAndZones.form.angle.error.range") })
+        .max(360, { message: t("masksAndZones.form.angle.error.range") })
+        .optional()
+        .or(z.literal("")),
+      angle_end: z.coerce
+        .number()
+        .min(0, { message: t("masksAndZones.form.angle.error.range") })
+        .max(360, { message: t("masksAndZones.form.angle.error.range") })
+        .optional()
+        .or(z.literal("")),
     })
     .refine(
       (data) => {
@@ -260,6 +283,8 @@ export default function ZoneEditPane({
         polygon?.camera &&
         polygon?.name &&
         config?.cameras[polygon.camera]?.zones[polygon.name]?.speed_threshold,
+      angle_start: angleStart,
+      angle_end: angleEnd,
     },
   });
 
@@ -289,6 +314,8 @@ export default function ZoneEditPane({
         lineC,
         lineD,
         speed_threshold,
+        angle_start,
+        angle_end,
       }: ZoneFormValuesType, // values submitted via the form
       objects: string[],
     ) => {
@@ -408,9 +435,20 @@ export default function ZoneEditPane({
         }
       }
 
+      let angleRangeQuery = "";
+      if (angle_start !== "" && angle_end !== "") {
+        angleRangeQuery = `&cameras.${polygon?.camera}.zones.${zoneName}.angle_range=${angle_start},${angle_end}`;
+      } else if (
+        polygon?.camera &&
+        polygon?.name &&
+        config?.cameras[polygon.camera]?.zones[polygon.name]?.angle_range
+      ) {
+        angleRangeQuery = `&cameras.${polygon?.camera}.zones.${zoneName}.angle_range`;
+      }
+
       axios
         .put(
-          `config/set?cameras.${polygon?.camera}.zones.${zoneName}.coordinates=${coordinates}${inertiaQuery}${loiteringTimeQuery}${speedThresholdQuery}${distancesQuery}${objectQueries}${alertQueries}${detectionQueries}`,
+          `config/set?cameras.${polygon?.camera}.zones.${zoneName}.coordinates=${coordinates}${inertiaQuery}${loiteringTimeQuery}${speedThresholdQuery}${angleRangeQuery}${distancesQuery}${objectQueries}${alertQueries}${detectionQueries}`,
           { requires_restart: 0 },
         )
         .then((res) => {
@@ -827,13 +865,51 @@ export default function ZoneEditPane({
                           {...field}
                         />
                       </FormControl>
-                      <FormDescription>
-                        {t("masksAndZones.zones.speedThreshold.desc")}
-                      </FormDescription>
+                    <FormDescription>
+                      {t("masksAndZones.zones.speedThreshold.desc")}
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex space-x-2">
+                <FormField
+                  control={form.control}
+                  name="angle_start"
+                  render={({ field }) => (
+                    <FormItem className="flex-1">
+                      <FormLabel>
+                        {t("masksAndZones.zones.directionFilter.start")}
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          className="text-md w-full border border-input bg-background p-2 hover:bg-accent hover:text-accent-foreground dark:[color-scheme:dark]"
+                          {...field}
+                        />
+                      </FormControl>
                       <FormMessage />
                     </FormItem>
                   )}
                 />
+                <FormField
+                  control={form.control}
+                  name="angle_end"
+                  render={({ field }) => (
+                    <FormItem className="flex-1">
+                      <FormLabel>
+                        {t("masksAndZones.zones.directionFilter.end")}
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          className="text-md w-full border border-input bg-background p-2 hover:bg-accent hover:text-accent-foreground dark:[color-scheme:dark]"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
               </>
             )}
 

--- a/web/src/types/canvas.ts
+++ b/web/src/types/canvas.ts
@@ -25,6 +25,8 @@ export type ZoneFormValuesType = {
   lineC: number;
   lineD: number;
   speed_threshold: number;
+  angle_start: number;
+  angle_end: number;
 };
 
 export type ObjectMaskFormValuesType = {

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -251,6 +251,7 @@ export interface CameraConfig {
       filters: Record<string, unknown>;
       inertia: number;
       loitering_time: number;
+      angle_range?: string[];
       speed_threshold: number;
       objects: string[];
       color: number[];


### PR DESCRIPTION
## Summary
- add API router for zone direction operations
- register zone router in FastAPI app
- document angle_range in config example and translations
- support angle filtering in zone settings UI
- add tests for new zone API endpoints
- fix deprecation warnings and clarify development docs

## Testing
- `ruff format frigate docs migrations`
- `ruff check frigate docs migrations`
- `python3 -m mypy --config-file frigate/mypy.ini frigate` *(fails: Library stubs not installed for `requests`, etc.)*
- `python3 -m unittest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_68430332333483329e35d197e1366879